### PR TITLE
event/fastfix isn't built as amd module

### DIFF
--- a/build/lib.js
+++ b/build/lib.js
@@ -15,6 +15,7 @@ steal(
 	'jquery/event/drag/scroll',
 	'jquery/event/drag/step',
 	"jquery/event/drop",
+	"jquery/event/fastfix",
 	"jquery/event/hover",
 	"jquery/event/key",
 	"jquery/event/pause",


### PR DESCRIPTION
the amd modules don't contains event/fasfix file
