### PR TITLE
Animation chaining error

### DIFF
--- a/dom/animate/animate.js
+++ b/dom/animate/animate.js
@@ -244,7 +244,7 @@ steal('jquery', 'jquery/dom/styles').then(function ($) {
 					}));
 
 					// Call the original callback
-					if (optall.old && exec) {
+					if (jQuery.isFunction(optall.old) && exec) {
 						// Call success, pass the DOM element as the this reference
 						optall.old.call(self[0], true)
 					}


### PR DESCRIPTION
When chaining animations ex. 
$(foo).animate({"width":1px},100,"ease-in").animate({"width":2px},100,"ease-in").
animate tries to call the easing property as a callback...
