### PR TITLE
Added dragcleanup event

### DIFF
--- a/event/drag/drag.js
+++ b/event/drag/drag.js
@@ -84,7 +84,8 @@ steal('jquery', 'jquery/lang/vector', 'jquery/event/livehack', 'jquery/event/rev
 					dragover: event.find(delegate, ["dragover"], selector),
 					dragmove: event.find(delegate, ["dragmove"], selector),
 					dragout: event.find(delegate, ["dragout"], selector),
-					dragend: event.find(delegate, ["dragend"], selector)
+					dragend: event.find(delegate, ["dragend"], selector),
+                                        dragcleanup: event.find(delegate, ["dragcleanup"], selector),
 				},
 				destroyed: function() {
 					self.current = null;
@@ -404,7 +405,7 @@ steal('jquery', 'jquery/lang/vector', 'jquery/event/livehack', 'jquery/event/rev
 				});
 			}
 			else {
-				this.cleanup();
+				this.cleanup(event);
 			}
 			this.event = null;
 		},
@@ -412,7 +413,7 @@ steal('jquery', 'jquery/lang/vector', 'jquery/event/livehack', 'jquery/event/rev
 		 * Cleans up drag element after drag drop.
 		 * @hide
 		 */
-		cleanup: function() {
+		cleanup: function(event) {
 			this.movingElement.css({
 				zIndex: this.oldZIndex
 			});
@@ -427,6 +428,8 @@ steal('jquery', 'jquery/lang/vector', 'jquery/event/livehack', 'jquery/event/rev
 				// Remove the element when using drag.ghost()
 				this.movingElement.remove();
 			}
+                        
+                        this.callEvents('cleanup', this.element, event);
 
 			this.movingElement = this.element = this.event = null;
 		},
@@ -713,15 +716,28 @@ steal('jquery', 'jquery/lang/vector', 'jquery/event/livehack', 'jquery/event/rev
 	 * @attribute dragend
 	 * @parent jQuery.event.drag
 	 *
-	 * `dragend` is called when the drag motion is done.
+	 * `dragend` is called when the drag operation is completed.
 	 * The event handler gets an instance of [jQuery.Drag] passed as the second
 	 * parameter.
 	 *
 	 *     $('.draggable').on('dragend', function(ev, drag)
-	 *       // Clean up when the drag motion is done
+	 *       // Calculation on whether revert should be invoked, alterations based on position of the end event
 	 *     });
 	 */
-	'dragend'], startEvent, function( e ) {
+	'dragend',
+        /**
+	 * @attribute dragcleanup
+	 * @parent jQuery.event.drag
+	 *
+	 * `dragcleanup` is called after dragend and revert (if applied)
+         * The event handler gets an instance of [jQuery.Drag] passed as the second
+	 * parameter.
+	 *
+	 *     $('.draggable').on('dragcleanup', function(ev, drag)
+	 *         // cleanup 
+	 *     });
+	 */
+	'dragcleanup'], startEvent, function( e ) {
 		$.Drag.mousedown.call($.Drag, e, this);
 	});
 


### PR DESCRIPTION
Currently there is no way to cleanup anything after the element has been reverted, this is the option I chose to implement a dragcleanup function that fires after dragend.
