### PR TITLE
namespace support for event.setuphelper

### DIFF
--- a/event/livehack/livehack.js
+++ b/event/livehack/livehack.js
@@ -124,18 +124,20 @@ steal('jquery', function($) {
 			startingEvent = null;
 		}
 		var add = function( handleObj ) {
-
-			var bySelector, selector = handleObj.selector || "";
+			var bySelector, 
+                            selector = handleObj.selector || "",
+                            namespace  = handleObj.namespace ? '.'+handleObj.namespace : '';
+                            
 			if ( selector ) {
 				bySelector = event.find(this, types, selector);
 				if (!bySelector.length ) {
-					$(this).delegate(selector, startingEvent, onFirst);
+					$(this).delegate(selector, startingEvent + namespace, onFirst);
 				}
 			}
 			else {
 				//var bySelector = event.find(this, types, selector);
 				if (!event.find(this, types, selector).length ) {
-					event.add(this, startingEvent, onFirst, {
+					event.add(this, startingEvent + namespace, onFirst, {
 						selector: selector,
 						delegate: this
 					});


### PR DESCRIPTION
The event.setupHelper does not add the namespace for the startingEvent varialbe, given the following setup:

```
$(this).on({
        'draginit.mover': $.proxy(this._setupDrag, this),
        'dragend.mover': $.proxy(this._cleanupDrag, this),
        'dragcleanup.mover': $.proxy(this._revertedDrag, this)
}) 
```

Calling:

```
$(this).off('.mover');
```

will release all but the mousedown event, because it's not currently namespaced.

Cheers,

Jay
