### PR TITLE
Fastfix: Original can be undefined

### DIFF
--- a/event/fastfix/fastfix.js
+++ b/event/fastfix/fastfix.js
@@ -22,13 +22,13 @@ steal('jquery', function ($) {
 					var eventDoc = this.target.ownerDocument || document;
 					doc = eventDoc.documentElement;
 					body = eventDoc.body;
-					return original.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && body.clientLeft || 0 );
+					return original && original.clientX + ( doc && doc.scrollLeft || body && body.scrollLeft || 0 ) - ( doc && doc.clientLeft || body && body.clientLeft || 0 );
 				},
 				pageY : function (original) {
 					var eventDoc = this.target.ownerDocument || document;
 					doc = eventDoc.documentElement;
 					body = eventDoc.body;
-					return original.clientY + ( doc && doc.scrollTop || body && body.scrollTop || 0 ) - ( doc && doc.clientTop || body && body.clientTop || 0 );
+					return original && original.clientY + ( doc && doc.scrollTop || body && body.scrollTop || 0 ) - ( doc && doc.clientTop || body && body.clientTop || 0 );
 				},
 				relatedTarget : function (original) {
 					if(!original) {
@@ -40,7 +40,7 @@ steal('jquery', function ($) {
 					return originalEvent.ctrlKey;
 				},
 				which : function (original) {
-					return original.charCode != null ? original.charCode : original.keyCode;
+					return original && (original.charCode != null ? original.charCode : original.keyCode);
 				}
 			};
 


### PR DESCRIPTION
Fixes pageX, pageY and which for when the original event does not exist and
the original value is undefined.

I was working with a jquery plugin that invokes mousemove like so

```
/trigger mousemove to move the knob to the current position
            $(document).on({
                mousemove: $.proxy(this.mousemove, this),
                mouseup: $.proxy(this.mouseup, this)
}).trigger('mousemove');
```

Since the mousemove handler handles actually mouse movements and this custom event, when calling:

```
var something = e.pageX || someothervalue;
```

It causes and error "original is undefined" I have not needed the which event but it most likely suffers from the same issue.
