### PR TITLE
removed .outerWidth() and .outerHeight() setters plugin and fixed dimensions animation bugs

### DIFF
--- a/dom/dimensions/dimensions.js
+++ b/dom/dimensions/dimensions.js
@@ -144,16 +144,16 @@ height:
 	var animate = function(boxes){
 		// Return the animation function
 		return function(fx){
-			if (fx.state == 0) {
+			if (fx.pos == 0) {
 	            fx.start = $(fx.elem)[lower]();
 	            fx.end = fx.end - getBoxes[lower](fx.elem,boxes);
 	        }
-	        fx.elem.style[lower] = (fx.pos * (fx.end - fx.start) + fx.start) + "px"
+	        fx.elem.style[lower] = (fx.pos * (fx.end - fx.start) + fx.start) + "px";
 		}
 	}
-    $.fx.step["outer" + Upper] = animate({padding: true, border: true})
-	$.fx.step["outer" + Upper+"Margin"] =  animate({padding: true, border: true, margin: true})
-	$.fx.step["inner" + Upper] = animate({padding: true})
+    $.fx.step["outer" + Upper] = animate({padding: true, border: true});
+	$.fx.step["outer" + Upper+"Margin"] =  animate({padding: true, border: true, margin: true});
+	$.fx.step["inner" + Upper] = animate({padding: true});
 
 })
 


### PR DESCRIPTION
We must remove .outerWidth() and .outerHeight() setters plugin because Jquery has supported them after version 1.8.0 (http://blog.jquery.com/2012/08/16/jquery-1-8-box-sizing-width-csswidth-and-outerwidth/). When they are removed, bug fixed for [this issue](https://github.com/jupiterjs/jquerypp/issues/48) 
