### PR TITLE
[FormParams] convertValue function: Null value to undefined (Internet Explorer Fix)

### DIFF
--- a/dom/form_params/form_params.js
+++ b/dom/form_params/form_params.js
@@ -10,7 +10,7 @@ steal("jquery", function( $ ) {
 				return true;
 			} else if ( value === 'false' ) {
 				return false;
-			} else if ( value === '' ) {
+			} else if ( value === '' || value === null ) {
 				return undefined;
 			}
 			return value;


### PR DESCRIPTION
Null value to undefined (Internet Explorer Fix).

Internet Explorer does not convert null values to undefined or empty values.
