### PR TITLE
Fix issue with dropon event not working on touch devices

### DIFF
--- a/lang/vector/vector.js
+++ b/lang/vector/vector.js
@@ -214,8 +214,8 @@ steal('jquery', function($){
 
 	$.Event.prototype.vector = function() {
 		// Get the first touch element for touch events
-		var touches = "ontouchend" in document && this.originalEvent.changedTouches.length
-				? this.originalEvent.changedTouches[0] : this;
+		var touches = "ontouchend" in document && this.originalEvent.changedTouches && 
+			this.originalEvent.changedTouches.length ? this.originalEvent.changedTouches[0] : this;
 		if ( this.originalEvent.synthetic ) {
 			var doc = document.documentElement,
 				body = document.body;


### PR DESCRIPTION
My fix is inspired by this one here: https://github.com/whatisjasongoldstein/jquerypp/commit/1e04f542683c3b2ea7186abe3301dd7a47bdc921
That fix introduced redundancies and didn't solve the problem cleanly, so I improved it.

From what I understood, the bug was that the previous code would not make use of originalEvent.changedTouches[0] if originalEvent.touches was empty - Which is incorrect behavior in the case of a dropon event.

In reality, it is possible to have an empty originalEvent.touches array, and yet have some originalEvent.changedTouches (I.e. Immediately after the finger is lifted from the touchscreen).
