### PR TITLE
Typo breaks `class` for newer versions of StealJS

### DIFF
--- a/class/class.js
+++ b/class/class.js
@@ -5,4 +5,4 @@
 //!steal-clean
 steal("jquery", "can/construct", "can/construct/proxy","can/construct/super", function($, Construct) {
 	$.Class = Construct;
-})();
+});


### PR DESCRIPTION
With the legacy version of StealJS, the typo appears to do nothing, which explains why it hasn't been brought up before.
