### PR TITLE
Edge 13 doesn't make animations with value auto

### DIFF
--- a/dom/animate/animate.js
+++ b/dom/animate/animate.js
@@ -284,8 +284,9 @@ steal('jquery', function ($) {
 				properties.push(prop);
 			}
 
-			if(getBrowser().prefix === '-moz-') {
+			if(getBrowser().prefix === '-moz-' || /Edge\/\d+/.test(navigator.userAgent)) {
 				// Normalize 'auto' properties in FF
+				// This is also needed in Edge (tested in 13)
 				$.each(properties, function(i, prop) {
 					var converter = ffProps[$.camelCase(prop)];
 					if(converter && self.css(prop) == 'auto') {


### PR DESCRIPTION
Solving a bug in Microsoft Edge where the animation is not even started when the starting value is auto, much like Firefox; adding an OR to detect Edge in the Firefox handling code, does the trick.

I couldn't test the solution past Edge 13.0.