### PR TITLE
Logic issue fixed

### DIFF
--- a/dom/animate/animate.js
+++ b/dom/animate/animate.js
@@ -68,7 +68,7 @@ steal('jquery', function ($) {
 				// Animating empty properties
 				$.isEmptyObject(props) ||
 				// We can't do custom easing
-				(easing || easing && typeof easing == 'string') ||
+				(easing && typeof easing == 'string') ||
 				// Second parameter is an object - we can only handle primitives
 				$.isPlainObject(ops) ||
 				// Inline and non elements


### PR DESCRIPTION
```js
Boolean(easing || easing && typeof easing == 'string' )
```
is equivalent with
```js
Boolean(easing)
```

So I quess the correct form is:

```js
easing && typeof easing == 'string'
```